### PR TITLE
(#15543) Fix loading of puppetlabs_spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
 dir = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.unshift File.join(dir, 'lib')
 
-require 'puppet_spec_helper'
+require 'puppetlabs_spec_helper/puppet_spec_helper'


### PR DESCRIPTION
**Don't merge this yet:** it seems to hit [issue #15545](http://projects.puppetlabs.com/issues/15545) in spec_helper where the puppet_spec_helper.rb doesn't initialise rspec properly.  Calling the module_spec_helper does work correctly, but since this doesn't use rspec-ruby, I'm not sure this is best.
