### PR TITLE
Better regular expressions for mountpoint paths.

### DIFF
--- a/lib/puppet/type/mountpoint.rb
+++ b/lib/puppet/type/mountpoint.rb
@@ -37,7 +37,7 @@ See the discussion under the mounttab type for usage."
     validate do |value|
       raise Puppet::Error, "name is not allowed to contain whitespace" if value =~ /\s/
       raise Puppet::Error, "name is not allowed to have trailing slashes" if value =~ %r{/$}
-      raise Puppet::Error, "name must be an absolute path" if value =~ %r{^[^/]} or value =~ %r{/../}
+      raise Puppet::Error, "name must be an absolute path" if value =~ %r{^[^/]} or value =~ %r{/\.\./}      
     end
   end
 


### PR DESCRIPTION
This changeset modifies the `mountpoint` regular expressions which determine absolute paths, to not error out in a couple of cases that I could find. I was trying to use two-character directory names - to wit, `/var/lib/pg/data` - and this regex was choking on them.

I've tried to make a general solution that works for all the forms of expressing a path.