### PR TITLE
(MODULES-2032) Fix Puppet.newtype deprecation warning

### DIFF
--- a/lib/puppet/type/mounttab.rb
+++ b/lib/puppet/type/mounttab.rb
@@ -2,7 +2,7 @@ require 'puppet/property/list'
 require 'puppet/provider/parsedfile'
 
 module Puppet
-  newtype(:mounttab) do
+  Type.newtype(:mounttab) do
     @doc = "Manages entries in the filesystem table. This is usually, but not
 necessarily, used in conjunction with the mountpoint type to manage both the
 current-running state of mounts (mountpoint) with the fstab entries which load


### PR DESCRIPTION
On Puppet 4 this module is throwing a deprecation warning because it is using Puppet.newtype to create the mounttab type. 
This PR converts it to use Puppet::Type.newtype.