### PR TITLE
(MODULES-4216) Avoiding remounts in case of a refresh event, when a m…

### DIFF
--- a/lib/puppet/type/mountpoint.rb
+++ b/lib/puppet/type/mountpoint.rb
@@ -5,7 +5,19 @@ See the discussion under the mounttab type for usage."
   feature :refreshable, "The provider can remount the filesystem.",
     :methods => [:remount]
 
-  ensurable
+  ensurable do
+    newvalue(:present, :invalidate_refreshes => true) do
+      unless provider.exists?
+        provider.create
+      end
+    end
+
+    newvalue(:absent) do
+      if provider.exists?
+        provider.destroy
+      end
+    end
+  end
 
   newproperty(:device) do
     desc "The device providing the mount.  This can be whatever


### PR DESCRIPTION
…ountpoint actually gets created.

By this fix refresh events are invalidated, when a mountpoint actually gets created. When a mountpoint's state is "absent", but it should be "present" and when this resource receives a refresh event, the share gets mounted and subsequently remounted. Especially in the case, when remounts are not implemented by the underlying driver, the mountpoint transition sequence looks as follows: "unmounted" -> "mounted" (caused by the property "ensure") -> "unmounted" -> "mounted" (caused by the refresh event). In case of remote shares, this behavior is very prone to failure.